### PR TITLE
[NavBar] Show the current item selected with an underline

### DIFF
--- a/components/header.react.tsx
+++ b/components/header.react.tsx
@@ -21,26 +21,39 @@ const Wrapper = styled.section`
   }
 `;
 
-const AnimatedLink = styled.a`
-  text-decoration: none;
-  position: relative;
-  :after {
-    content: "";
-    position: absolute;
-    bottom: 0;
-    left: 20%;
+/*
+Component styling to show underlined headings.
+Will animate the underlining of a menu item on mouse over and always
+show the underline under the selected item
+*/
+const NavBar = styled.h2`
+  a {
+    text-decoration: none;
+    position: relative;
+    :after {
+      content: "";
+      position: absolute;
+      bottom: 0;
+      left: 0%;
+      width: 0%;
+      border-bottom: 2px solid rgba(102, 153, 204, 0.4);
+      transition: 0.4s;
+    }
+    :not(:first-child):before {
+      content: " • ";
+    }
+    :hover:after {
+      width: 40% !important;
+    }
+  }
+  a.selected {
+    font-weight: 400;
+    :after {
+      width: 40%;
+    }
+  }
+  :hover a.selected:after {
     width: 0%;
-    border-bottom: 2px solid rgba(102, 153, 204, 0.4);
-    transition: 0.4s;
-  }
-  :hover:after {
-    width: 40%;
-  }
-`;
-
-const SelectedLink = styled(AnimatedLink)`
-  :after {
-    width: 40%;
   }
 `
 
@@ -50,23 +63,20 @@ interface SmartLinkProps {
 }
 
 function SmartLink(props: SmartLinkProps) {
-  if (props.underlined) {
-    return <SelectedLink>{props.text}</SelectedLink>;
-  }
-  return <AnimatedLink>{props.text}</AnimatedLink>;
+  return <a className={props.underlined ? "selected" : undefined}>{props.text}</a>;
 }
 
 export default function Header() {
   return (
     <Wrapper>
       <h1>Scott O'Brien</h1>
-      <h2>
-        <SmartLink text="Writings/Projects" underlined />&nbsp;&#x2022;&nbsp;
-        <SmartLink text="About" />&nbsp;&#x2022;&nbsp;
-        <SmartLink text="Bucket List" />&nbsp;&#x2022;&nbsp;
-        <SmartLink text="Cooking" />&nbsp;&#x2022;&nbsp;
+      <NavBar>
+        <SmartLink text="Writings/Projects" underlined />
+        <SmartLink text="About" />
+        <SmartLink text="BucketList" />
+        <SmartLink text="Cooking" />
         <SmartLink text="Flying" />
-      </h2>
+      </NavBar>
     </Wrapper>
   );
 }


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/scottyob/nextjs-website/pull/7).
* __->__ #7

[NavBar] Show the current item selected with an underline

Summary:
Shows styling of underlining the mouse-overed element.  When there is no mouse over, it will instead show the "selected" item with the underline.

Issues:
- Pullet point added with :before, means that the left: 0% starts in the wrong place
- When the screen is resized fairly small, the right-most selected item has its underline dissapear

Test Plan:
Help!! Lol

